### PR TITLE
feat: add date selection constraint properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ app.use(ROCDatePicker);
 - `disabled`: 是否禁用日期選擇器。
 - `zIndex`: 元素的 z-index。
 - `showClearButton`: 是否顯示清除按鈕。
+- `minDate`: 可選日期下限（包含）。
+- `maxDate`: 可選日期上限（包含）。
+- `disableWeekends`: 是否禁用週六與週日。
+- `disabledDates`: 指定不可選日期清單。
 
 | Name                | Description                                | Type                   | Accepted Values                     | Default Value |
 |---------------------|--------------------------------------------|------------------------|-------------------------------------|---------------|
@@ -47,3 +51,7 @@ app.use(ROCDatePicker);
 | `disabled`          | Whether the date picker is disabled. | Boolean                | `true` or `false`                   | false         |
 | `zIndex`            | Z-index of the pop-up calendar.      | Number                 | Any valid positive integer          | 1             |
 | `showClearButton`   | Whether to show the clear button.    | Boolean                | `true` or `false`                   | true          |
+| `minDate`           | Minimum selectable date (inclusive). | Date \| String         | Valid date value                    | -             |
+| `maxDate`           | Maximum selectable date (inclusive). | Date \| String         | Valid date value                    | -             |
+| `disableWeekends`   | Disable Saturdays and Sundays.       | Boolean                | `true` or `false`                   | false         |
+| `disabledDates`     | Explicit list of disabled dates.     | (Date \| String)[]     | Valid date values                   | []            |

--- a/src/components/ROCDatePicker.vue
+++ b/src/components/ROCDatePicker.vue
@@ -160,6 +160,10 @@
             :calendar-year="yearOnCalendar"
             :calendar-month="monthOnCalendar"
             :default-full-date="selectedTime"
+            :min-date="minDate"
+            :max-date="maxDate"
+            :disable-weekends="disableWeekends"
+            :disabled-dates="disabledDates"
             @click="handleDateChange"
           />
         </div>
@@ -248,12 +252,33 @@ export default defineComponent({
     showClearButton: {
       type: Boolean,
       default: true
+    },
+    minDate: {
+      type: [Date, String],
+      default: undefined
+    },
+    maxDate: {
+      type: [Date, String],
+      default: undefined
+    },
+    disableWeekends: {
+      type: Boolean,
+      default: false
+    },
+    disabledDates: {
+      type: Array as PropType<(Date | string)[]>,
+      default: () => []
     }
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
     const {
-      type, defaultValue, disabled, calendarYearType, lang, modelValue
+      type,
+      defaultValue,
+      disabled,
+      calendarYearType,
+      lang,
+      modelValue
     } = toRefs(props);
     const isCalendarVisible = ref(false);
     const isDateCalendarVisible = ref(false);

--- a/src/components/__tests__/date-calendar.test.ts
+++ b/src/components/__tests__/date-calendar.test.ts
@@ -85,5 +85,45 @@ describe('Test Component DateCalendar', () => {
     expect(selectedFullDate).toStrictEqual(wrapper.vm.defaultFullDate);
   });
 
+  it('should disable weekend dates when disableWeekends is true', async () => {
+    const wrapper = mount(DateCalendar, {
+      props: {
+        ...defaultProps,
+        disableWeekends: true
+      }
+    });
+
+    await wrapper.vm.$nextTick();
+    const dateCells = wrapper.findAll('[data-test="date-cell"]');
+    const weekendDateCell = dateCells.find((cell) => cell.text() === '2');
+    expect(weekendDateCell?.attributes('disabled')).toBeDefined();
+
+    await weekendDateCell?.trigger('click');
+    expect(wrapper.vm.selectedFullDate.timeValue).toBeUndefined();
+  });
+
+  it('should disable dates by min/max range and disabledDates', async () => {
+    const wrapper = mount(DateCalendar, {
+      props: {
+        ...defaultProps,
+        minDate: '2023-09-10',
+        maxDate: '2023-09-20',
+        disabledDates: ['2023-09-11']
+      }
+    });
+
+    await wrapper.vm.$nextTick();
+    const dateCells = wrapper.findAll('[data-test="date-cell"]');
+    const beforeMinDateCell = dateCells.find((cell) => cell.text() === '9');
+    const disabledDateCell = dateCells.find((cell) => cell.text() === '11');
+    const validDateCell = dateCells.find((cell) => cell.text() === '12');
+    const afterMaxDateCell = dateCells.find((cell) => cell.text() === '21');
+
+    expect(beforeMinDateCell?.attributes('disabled')).toBeDefined();
+    expect(disabledDateCell?.attributes('disabled')).toBeDefined();
+    expect(validDateCell?.attributes('disabled')).toBeUndefined();
+    expect(afterMaxDateCell?.attributes('disabled')).toBeDefined();
+  });
+
   it.todo('show different color of the date today');
 });

--- a/src/components/calendar/DateCalendar.vue
+++ b/src/components/calendar/DateCalendar.vue
@@ -18,11 +18,14 @@
           :class="[
             'date-cell',
             {
-              'cursor-pointer': date, 'selected-date': isSelected(date),
+              'cursor-pointer': date && !isDateDisabled(date),
+              'disabled-date': date && isDateDisabled(date),
+              'selected-date': isSelected(date),
             },
           ]"
           data-test="date-cell"
           type="button"
+          :disabled="!date || isDateDisabled(date)"
           @click="handleSelectDate(date)"
         >
           {{ date }}
@@ -65,13 +68,72 @@ export default defineComponent({
     defaultFullDate: {
       type: Object as PropType<SelectedTime>,
       default: () => ({})
+    },
+    minDate: {
+      type: [Date, String] as PropType<Date | string | undefined>,
+      default: undefined
+    },
+    maxDate: {
+      type: [Date, String] as PropType<Date | string | undefined>,
+      default: undefined
+    },
+    disableWeekends: {
+      type: Boolean,
+      default: false
+    },
+    disabledDates: {
+      type: Array as PropType<(Date | string)[]>,
+      default: () => []
     }
   },
   emits: ['click'],
   setup(props, { emit }) {
     const {
-      calendarYear, calendarMonth, calendarYearType, defaultFullDate
+      calendarYear,
+      calendarMonth,
+      calendarYearType,
+      defaultFullDate,
+      minDate,
+      maxDate,
+      disableWeekends,
+      disabledDates
     } = toRefs(props);
+    const toDateOnlyTimestamp = (input?: Date | string) => {
+      if (!input) return undefined;
+      const parsed = dayjs(input);
+      if (!parsed.isValid()) return undefined;
+      return parsed.startOf('day').valueOf();
+    };
+
+    const disabledDateSet = computed(() => new Set(
+      disabledDates.value
+        .map((date) => toDateOnlyTimestamp(date))
+        .filter((date): date is number => date !== undefined)
+    ));
+
+    const minDateTimestamp = computed(() => toDateOnlyTimestamp(minDate.value));
+    const maxDateTimestamp = computed(() => toDateOnlyTimestamp(maxDate.value));
+
+    const isDateDisabled = (dateOnCalendar: number | null) => {
+      if (!dateOnCalendar) return true;
+      const targetDate = dayjs(new Date(calendarYear.value, calendarMonth.value, dateOnCalendar));
+      const targetDateTimestamp = targetDate.startOf('day').valueOf();
+
+      if (minDateTimestamp.value !== undefined && targetDateTimestamp < minDateTimestamp.value) {
+        return true;
+      }
+
+      if (maxDateTimestamp.value !== undefined && targetDateTimestamp > maxDateTimestamp.value) {
+        return true;
+      }
+
+      if (disableWeekends.value && [0, 6].includes(targetDate.day())) {
+        return true;
+      }
+
+      return disabledDateSet.value.has(targetDateTimestamp);
+    };
+
     const dateCells = ref<(number | null)[]>([]);
     const selectedFullDate = ref<SelectedTime>({});
 
@@ -93,7 +155,7 @@ export default defineComponent({
     };
 
     const handleSelectDate = (dateOnCalendar: number | null) => {
-      if (!dateOnCalendar) return;
+      if (!dateOnCalendar || isDateDisabled(dateOnCalendar)) return;
       selectedFullDate.value.timeValue = new Date(calendarYear.value, calendarMonth.value, dateOnCalendar);
 
       selectedFullDate.value.label = setDatePickerLabel({
@@ -137,6 +199,7 @@ export default defineComponent({
       selectedFullDate,
       populateDateCalendar,
       isSelected,
+      isDateDisabled,
       handleSelectDate,
       getCalendarLang
     };
@@ -180,6 +243,15 @@ button {
 
     &:hover {
       color: #4390BC;
+    }
+  }
+
+  .disabled-date {
+    opacity: 0.5;
+    cursor: not-allowed;
+
+    &:hover {
+      color: #6a6c6d;
     }
   }
 


### PR DESCRIPTION
Implement new properties to control date selection in the calendar:
- `minDate`: Set a minimum selectable date.
- `maxDate`: Set a maximum selectable date.
- `disableWeekends`: Prevent selection of Saturday and Sunday.
- `disabledDates`: Provide an explicit list of dates that cannot be selected.

These properties are passed down from `ROCDatePicker` to `DateCalendar` and validated through new tests. The README has been updated to reflect these additions.