### PR TITLE
feat: add date selection constraint properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ app.use(ROCDatePicker);
 - `showTodayButton`: 是否顯示今天快捷按鈕。
 - `closeOnClickOutside`: 點擊元件外部時是否自動關閉。
 - `closeOnEscape`: 按下 `Esc` 時是否自動關閉。
+- `disableWeekends`: 是否禁用週六與週日。
+- `disabledDates`: 指定不可選日期清單。
 
 | Name                | Description                                | Type                   | Accepted Values                     | Default Value |
 |---------------------|--------------------------------------------|------------------------|-------------------------------------|---------------|
@@ -65,3 +67,5 @@ app.use(ROCDatePicker);
 | `showTodayButton`    | Show a shortcut button that selects today. | Boolean           | `true` or `false`                   | false         |
 | `closeOnClickOutside` | Close the calendar when clicking outside. | Boolean           | `true` or `false`                   | true          |
 | `closeOnEscape`      | Close the calendar when pressing `Esc`.    | Boolean           | `true` or `false`                   | true          |
+| `disableWeekends`   | Disable Saturdays and Sundays.       | Boolean                | `true` or `false`                   | false         |
+| `disabledDates`     | Explicit list of disabled dates.     | (Date \| String)[]     | Valid date values                   | []            |

--- a/src/components/ROCDatePicker.vue
+++ b/src/components/ROCDatePicker.vue
@@ -176,6 +176,8 @@
             :default-full-date="selectedTime"
             :min-date="minDate"
             :max-date="maxDate"
+            :disable-weekends="disableWeekends"
+            :disabled-dates="disabledDates"
             @click="handleDateChange"
           />
         </div>
@@ -215,7 +217,7 @@ import {
   getCalendarLang,
   getRepublicEraYear,
   getValidDate,
-  isDateOutOfRange,
+  isDateOutsideRange,
   setDatePickerLabel
 } from '@/utils';
 import {
@@ -280,14 +282,6 @@ export default defineComponent({
       type: [Date, String],
       default: ''
     },
-    minDate: {
-      type: [Date, String],
-      default: ''
-    },
-    maxDate: {
-      type: [Date, String],
-      default: ''
-    },
     disabled: {
       type: Boolean,
       default: false
@@ -311,6 +305,22 @@ export default defineComponent({
     closeOnEscape: {
       type: Boolean,
       default: true
+    },
+    minDate: {
+      type: [Date, String],
+      default: undefined
+    },
+    maxDate: {
+      type: [Date, String],
+      default: undefined
+    },
+    disableWeekends: {
+      type: Boolean,
+      default: false
+    },
+    disabledDates: {
+      type: Array as PropType<(Date | string)[]>,
+      default: () => []
     }
   },
   emits: ['update:modelValue'],
@@ -348,7 +358,7 @@ export default defineComponent({
     const canGoNextMonth = ref(true);
     const canGoNextDecade = ref(true);
     const selectedTime = ref<SelectedTime>({ ...DEFAULT_SELECTED_TIME });
-    const isTodayDisabled = computed(() => isDateOutOfRange({
+    const isTodayDisabled = computed(() => isDateOutsideRange({
       targetDate: new Date(),
       minDate: minDate.value,
       maxDate: maxDate.value
@@ -435,7 +445,7 @@ export default defineComponent({
       canGoLastYear.value = !((yearType.value === YearType.RepublicEra
         && yearOnCalendar.value <= 1912)
         || currentDecadeStart <= 100
-        || isDateOutOfRange({
+        || isDateOutsideRange({
           targetDate: new Date(
             previousYearValue,
             isMonthCalendarVisible.value ? 11 : monthOnCalendar.value,
@@ -449,7 +459,7 @@ export default defineComponent({
       canGoLastMonth.value = !(yearType.value === YearType.RepublicEra
         && yearOnCalendar.value <= 1912
         && monthOnCalendar.value === 0)
-        && !isDateOutOfRange({
+        && !isDateOutsideRange({
           targetDate: new Date(previousMonthYear, previousMonthValue, 1),
           minDate: minDate.value,
           unit: 'month'
@@ -458,25 +468,25 @@ export default defineComponent({
       canGoLastDecade.value = currentDecadeStart > 100
         && !((yearType.value === YearType.RepublicEra)
         && getRepublicEraYear(currentDecadeStart) < 1);
-      canGoLastDecade.value = canGoLastDecade.value && !isDateOutOfRange({
+      canGoLastDecade.value = canGoLastDecade.value && !isDateOutsideRange({
         targetDate: new Date(currentDecadeStart - 1, 11, 31),
         minDate: minDate.value,
         unit: 'year'
       });
 
-      canGoNextYear.value = !isDateOutOfRange({
+      canGoNextYear.value = !isDateOutsideRange({
         targetDate: new Date(nextYearValue, monthOnCalendar.value, 1),
         maxDate: maxDate.value,
         unit: isMonthCalendarVisible.value ? 'year' : 'month'
       });
 
-      canGoNextMonth.value = !isDateOutOfRange({
+      canGoNextMonth.value = !isDateOutsideRange({
         targetDate: new Date(nextMonthYear, nextMonthValue, 1),
         maxDate: maxDate.value,
         unit: 'month'
       });
 
-      canGoNextDecade.value = !isDateOutOfRange({
+      canGoNextDecade.value = !isDateOutsideRange({
         targetDate: new Date(currentDecadeStart + 10, 0, 1),
         maxDate: maxDate.value,
         unit: 'year'

--- a/src/components/__tests__/date-calendar.test.ts
+++ b/src/components/__tests__/date-calendar.test.ts
@@ -14,7 +14,7 @@ describe('Test Component DateCalendar', () => {
     calendarYearType: YearType.RepublicEra
   };
 
-  it('populate date cells properly', async () => {
+  it('populates date cells correctly', async () => {
     const wrapper = mount(DateCalendar, {
       props: { ...defaultProps }
     });
@@ -32,7 +32,7 @@ describe('Test Component DateCalendar', () => {
     expect(wrapper.vm.dateCells[6]).toBe(1);
   });
 
-  it('handle select date properly', async () => {
+  it('handles date selection', async () => {
     const wrapper = mount(DateCalendar, {
       props: {
         ...defaultProps
@@ -70,7 +70,7 @@ describe('Test Component DateCalendar', () => {
     });
   });
 
-  it('selectedFullDate equals to defaultFullDate if it exists', () => {
+  it('keeps selectedFullDate in sync with defaultFullDate', () => {
     const wrapper = mount(DateCalendar, {
       props: {
         ...defaultProps,
@@ -85,7 +85,7 @@ describe('Test Component DateCalendar', () => {
     expect(selectedFullDate).toStrictEqual(wrapper.vm.defaultFullDate);
   });
 
-  it('show different color of the date today', async () => {
+  it('highlights today\'s date', async () => {
     const today = new Date();
     const wrapper = mount(DateCalendar, {
       props: {
@@ -99,7 +99,7 @@ describe('Test Component DateCalendar', () => {
     expect(wrapper.find('.today-date').exists()).toBe(true);
   });
 
-  it('should disable weekend dates when disableWeekends is true', async () => {
+  it('disables weekend dates when disableWeekends is true', async () => {
     const wrapper = mount(DateCalendar, {
       props: {
         ...defaultProps,
@@ -116,7 +116,7 @@ describe('Test Component DateCalendar', () => {
     expect(wrapper.vm.selectedFullDate.timeValue).toBeUndefined();
   });
 
-  it('should disable dates by min/max range and disabledDates', async () => {
+  it('disables dates by min/max range and disabledDates', async () => {
     const wrapper = mount(DateCalendar, {
       props: {
         ...defaultProps,

--- a/src/components/__tests__/date-calendar.test.ts
+++ b/src/components/__tests__/date-calendar.test.ts
@@ -99,27 +99,43 @@ describe('Test Component DateCalendar', () => {
     expect(wrapper.find('.today-date').exists()).toBe(true);
   });
 
-  it('disable dates outside min and max range', async () => {
+  it('should disable weekend dates when disableWeekends is true', async () => {
     const wrapper = mount(DateCalendar, {
       props: {
         ...defaultProps,
-        minDate: '2023-09-10',
-        maxDate: '2023-09-20'
+        disableWeekends: true
       }
     });
 
     await wrapper.vm.$nextTick();
+    const dateCells = wrapper.findAll('[data-test="date-cell"]');
+    const weekendDateCell = dateCells.find((cell) => cell.text() === '2');
+    expect(weekendDateCell?.attributes('disabled')).toBeDefined();
 
-    const disabledCell = wrapper.find('.disabled-date');
-    const enabledCell = wrapper.findAll('[data-test="date-cell"]').find((cell) => cell.text() === '10');
+    await weekendDateCell?.trigger('click');
+    expect(wrapper.vm.selectedFullDate.timeValue).toBeUndefined();
+  });
 
-    expect(disabledCell.exists()).toBe(true);
-    expect(enabledCell?.attributes('disabled')).toBeUndefined();
+  it('should disable dates by min/max range and disabledDates', async () => {
+    const wrapper = mount(DateCalendar, {
+      props: {
+        ...defaultProps,
+        minDate: '2023-09-10',
+        maxDate: '2023-09-20',
+        disabledDates: ['2023-09-11']
+      }
+    });
 
-    await disabledCell.trigger('click');
-    expect(wrapper.emitted('click')).toBeFalsy();
+    await wrapper.vm.$nextTick();
+    const dateCells = wrapper.findAll('[data-test="date-cell"]');
+    const beforeMinDateCell = dateCells.find((cell) => cell.text() === '9');
+    const disabledDateCell = dateCells.find((cell) => cell.text() === '11');
+    const validDateCell = dateCells.find((cell) => cell.text() === '12');
+    const afterMaxDateCell = dateCells.find((cell) => cell.text() === '21');
 
-    await enabledCell?.trigger('click');
-    expect(wrapper.emitted('click')).toBeTruthy();
+    expect(beforeMinDateCell?.attributes('disabled')).toBeDefined();
+    expect(disabledDateCell?.attributes('disabled')).toBeDefined();
+    expect(validDateCell?.attributes('disabled')).toBeUndefined();
+    expect(afterMaxDateCell?.attributes('disabled')).toBeDefined();
   });
 });

--- a/src/components/__tests__/month-calendar.test.ts
+++ b/src/components/__tests__/month-calendar.test.ts
@@ -13,7 +13,7 @@ describe('Test Component MonthCalendar', () => {
     calendarYear: new Date().getFullYear()
   };
 
-  it('render month calendar properly', async () => {
+  it('renders month calendar', async () => {
     const wrapper = mount(MonthCalendar, {
       props: { ...defaultProps }
     });
@@ -24,7 +24,7 @@ describe('Test Component MonthCalendar', () => {
     });
   });
 
-  it('handle select month properly', async () => {
+  it('handles month selection', async () => {
     const wrapper = mount(MonthCalendar, {
       props: {
         ...defaultProps
@@ -53,7 +53,7 @@ describe('Test Component MonthCalendar', () => {
     expect(labelPattern.test(selectedTimeLabel)).toBe(true);
   });
 
-  it('selectedFullDate equals to defaultFullDate if it exists', () => {
+  it('keeps selectedFullDate in sync with defaultFullDate', () => {
     const wrapper = mount(MonthCalendar, {
       props: {
         ...defaultProps,
@@ -68,7 +68,7 @@ describe('Test Component MonthCalendar', () => {
     expect(selectedFullDate).toStrictEqual(wrapper.vm.defaultFullDate);
   });
 
-  it('disable months outside min and max range', async () => {
+  it('disables months outside min and max range', async () => {
     const wrapper = mount(MonthCalendar, {
       props: {
         ...defaultProps,

--- a/src/components/__tests__/year-calendar.test.ts
+++ b/src/components/__tests__/year-calendar.test.ts
@@ -12,7 +12,7 @@ describe('Test Component YearCalendar', () => {
     decadeRange: []
   };
 
-  it('populate years properly', async () => {
+  it('populates years correctly', async () => {
     const wrapper = mount(YearCalendar, {
       props: { ...defaultProps }
     });
@@ -30,7 +30,7 @@ describe('Test Component YearCalendar', () => {
     expect(wrapper.vm.years).not.toContain(1920);
   });
 
-  it('handle select year properly', async () => {
+  it('handles year selection', async () => {
     const wrapper = mount(YearCalendar, {
       props: {
         ...defaultProps,
@@ -69,7 +69,7 @@ describe('Test Component YearCalendar', () => {
     expect(emittedValues![0]).toEqual([wrapper.vm.selectedFullDate]);
   });
 
-  it('selectedFullDate equals to defaultFullDate if it exists', () => {
+  it('keeps selectedFullDate in sync with defaultFullDate', () => {
     const wrapper = mount(YearCalendar, {
       props: {
         ...defaultProps,
@@ -85,7 +85,7 @@ describe('Test Component YearCalendar', () => {
     expect(selectedFullDate).toStrictEqual(wrapper.vm.defaultFullDate);
   });
 
-  it('render years according to different year type', async () => {
+  it('renders years for each year type', async () => {
     const wrapper = mount(YearCalendar, {
       props: {
         ...defaultProps,
@@ -109,7 +109,7 @@ describe('Test Component YearCalendar', () => {
     expect(yearCell).toBe(`${wrapper.vm.years[randomIndex]}`);
   });
 
-  it('disable years outside min and max range', async () => {
+  it('disables years outside min and max range', async () => {
     const wrapper = mount(YearCalendar, {
       props: {
         ...defaultProps,

--- a/src/components/calendar/DateCalendar.vue
+++ b/src/components/calendar/DateCalendar.vue
@@ -42,7 +42,7 @@ import {
   CalendarType, Language, YearType, type SelectedTime
 } from '@/interfaces';
 import {
-  getCalendarLang, isDateDisabled as isCalendarDateDisabled, setDatePickerLabel
+  getCalendarLang, isCalendarDateDisabled, setDatePickerLabel
 } from '@/utils';
 import dayjs from 'dayjs';
 import {

--- a/src/components/calendar/DateCalendar.vue
+++ b/src/components/calendar/DateCalendar.vue
@@ -42,7 +42,7 @@ import {
   CalendarType, Language, YearType, type SelectedTime
 } from '@/interfaces';
 import {
-  getCalendarLang, isDateOutOfRange, setDatePickerLabel
+  getCalendarLang, isDateDisabled as isCalendarDateDisabled, setDatePickerLabel
 } from '@/utils';
 import dayjs from 'dayjs';
 import {
@@ -78,19 +78,48 @@ export default defineComponent({
       default: () => ({ ...DEFAULT_SELECTED_TIME })
     },
     minDate: {
-      type: [Date, String],
-      default: ''
+      type: [Date, String] as PropType<Date | string | undefined>,
+      default: undefined
     },
     maxDate: {
-      type: [Date, String],
-      default: ''
+      type: [Date, String] as PropType<Date | string | undefined>,
+      default: undefined
+    },
+    disableWeekends: {
+      type: Boolean,
+      default: false
+    },
+    disabledDates: {
+      type: Array as PropType<(Date | string)[]>,
+      default: () => []
     }
   },
   emits: ['click'],
   setup(props, { emit }) {
     const {
-      calendarYear, calendarMonth, calendarYearType, defaultFullDate, minDate, maxDate
+      calendarYear,
+      calendarMonth,
+      calendarYearType,
+      defaultFullDate,
+      minDate,
+      maxDate,
+      disableWeekends,
+      disabledDates
     } = toRefs(props);
+
+    const isDateDisabled = (dateOnCalendar: number | null) => {
+      if (!dateOnCalendar) return true;
+
+      return isCalendarDateDisabled({
+        targetDate: new Date(calendarYear.value, calendarMonth.value, dateOnCalendar),
+        minDate: minDate.value,
+        maxDate: maxDate.value,
+        unit: 'day',
+        disableWeekends: disableWeekends.value,
+        disabledDates: disabledDates.value
+      });
+    };
+
     const dateCells = ref<(number | null)[]>([]);
     const selectedFullDate = ref<SelectedTime>({});
 
@@ -122,16 +151,6 @@ export default defineComponent({
       const currentDate = dayjs(new Date(calendarYear.value, calendarMonth.value, date));
 
       return currentDate.isSame(today, 'day');
-    };
-
-    const isDateDisabled = (date: number | null) => {
-      if (!date) return false;
-
-      return isDateOutOfRange({
-        targetDate: new Date(calendarYear.value, calendarMonth.value, date),
-        minDate: minDate.value,
-        maxDate: maxDate.value
-      });
     };
 
     const handleSelectDate = (dateOnCalendar: number | null) => {

--- a/src/components/calendar/MonthCalendar.vue
+++ b/src/components/calendar/MonthCalendar.vue
@@ -28,7 +28,7 @@
 <script lang="ts">
 import { MONTHS } from '@/constants';
 import {
-  getCalendarLang, isDateDisabled as isCalendarDateDisabled, setDatePickerLabel
+  getCalendarLang, isCalendarDateDisabled, setDatePickerLabel
 } from '@/utils';
 import {
   CalendarType, Language, YearType, type SelectedTime

--- a/src/components/calendar/MonthCalendar.vue
+++ b/src/components/calendar/MonthCalendar.vue
@@ -28,7 +28,7 @@
 <script lang="ts">
 import { MONTHS } from '@/constants';
 import {
-  getCalendarLang, isDateOutOfRange, setDatePickerLabel
+  getCalendarLang, isDateDisabled as isCalendarDateDisabled, setDatePickerLabel
 } from '@/utils';
 import {
   CalendarType, Language, YearType, type SelectedTime
@@ -101,7 +101,7 @@ export default defineComponent({
       return false;
     };
 
-    const isMonthDisabled = (month: number) => isDateOutOfRange({
+    const isMonthDisabled = (month: number) => isCalendarDateDisabled({
       targetDate: new Date(calendarYear.value, month, 1),
       minDate: minDate.value,
       maxDate: maxDate.value,

--- a/src/components/calendar/YearCalendar.vue
+++ b/src/components/calendar/YearCalendar.vue
@@ -27,7 +27,7 @@
 
 <script lang="ts">
 import {
-  getRepublicEraYear, isDateOutOfRange, setDatePickerLabel
+  getRepublicEraYear, isDateOutsideRange, setDatePickerLabel
 } from '@/utils';
 import {
   CalendarType, Language, YearType, type SelectedTime
@@ -113,7 +113,7 @@ export default defineComponent({
       return false;
     };
 
-    const isYearDisabled = (year: number) => isDateOutOfRange({
+    const isYearDisabled = (year: number) => isDateOutsideRange({
       targetDate: new Date(year, 0, 1),
       minDate: minDate.value,
       maxDate: maxDate.value,

--- a/src/utils/__tests__/format-date.test.ts
+++ b/src/utils/__tests__/format-date.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { formatDate } from '../index';
 
 describe('Test formatDate', () => {
-  it('pass (new Date(\'2023-09-15\'), YYYY/MM/DD) returns 2023/09/15', () => {
+  it('formats a date with the given pattern', () => {
     expect(formatDate(new Date('2023-09-15'), 'YYYY/MM/DD')).toBe('2023/09/15');
   });
 
-  it('pass (null, \'YYYY-MM-DD\') returns \'\'', () => {
+  it('returns an empty string for null input', () => {
     expect(formatDate(null, 'YYYY-MM-DD')).toBe('');
   });
 });

--- a/src/utils/__tests__/get-calendar-lang.test.ts
+++ b/src/utils/__tests__/get-calendar-lang.test.ts
@@ -4,15 +4,15 @@ import { Language } from '@/interfaces';
 import { getCalendarLang } from '../index';
 
 describe('Test getCalendarLang', () => {
-  it('pass \'zhTW\' returns zhTW locale', () => {
+  it('returns zhTW locale for zhTW', () => {
     expect(getCalendarLang(Language.ZH_TW)).toEqual(TRANSLATE.zhTW);
   });
 
-  it('pass \'en\' returns en locale', () => {
+  it('returns en locale for en', () => {
     expect(getCalendarLang(Language.EN)).toEqual(TRANSLATE.en);
   });
 
-  it('pass unsupported language returns en locale', () => {
+  it('falls back to en locale for unsupported language', () => {
     // @ts-ignore
     expect(getCalendarLang('zhCN')).toEqual(TRANSLATE.en);
   });

--- a/src/utils/__tests__/get-republic-era-year.test.ts
+++ b/src/utils/__tests__/get-republic-era-year.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { getRepublicEraYear } from '../index';
 
 describe('Test getRepublicEraYear', () => {
-  it('pass 2023 returns 112', () => {
+  it('converts 2023 to 112', () => {
     expect(getRepublicEraYear(2023)).toBe(112);
   });
 
-  it('pass 1900 returns -11', () => {
+  it('converts 1900 to -11', () => {
     expect(getRepublicEraYear(1900)).toBe(-11);
   });
 });

--- a/src/utils/__tests__/is-date-disabled.test.ts
+++ b/src/utils/__tests__/is-date-disabled.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isDateDisabled } from '../index';
+
+describe('Test isDateDisabled', () => {
+  it('returns true for dates outside min/max range', () => {
+    expect(isDateDisabled({
+      targetDate: '2023-09-09',
+      minDate: '2023-09-10'
+    })).toBe(true);
+
+    expect(isDateDisabled({
+      targetDate: '2023-09-21',
+      maxDate: '2023-09-20'
+    })).toBe(true);
+  });
+
+  it('returns true for weekend dates when disableWeekends is enabled', () => {
+    expect(isDateDisabled({
+      targetDate: '2023-09-10',
+      disableWeekends: true
+    })).toBe(true);
+  });
+
+  it('returns true for explicitly disabled dates', () => {
+    expect(isDateDisabled({
+      targetDate: '2023-09-11',
+      disabledDates: ['2023-09-11']
+    })).toBe(true);
+  });
+
+  it('supports month boundary checks', () => {
+    expect(isDateDisabled({
+      targetDate: new Date(2023, 8, 1),
+      minDate: '2023-09-01',
+      maxDate: '2023-12-31',
+      unit: 'month'
+    })).toBe(false);
+
+    expect(isDateDisabled({
+      targetDate: new Date(2023, 7, 1),
+      minDate: '2023-09-01',
+      unit: 'month'
+    })).toBe(true);
+  });
+});

--- a/src/utils/__tests__/is-date-disabled.test.ts
+++ b/src/utils/__tests__/is-date-disabled.test.ts
@@ -1,42 +1,42 @@
 import { describe, expect, it } from 'vitest';
-import { isDateDisabled } from '../index';
+import { isCalendarDateDisabled } from '../index';
 
-describe('Test isDateDisabled', () => {
+describe('Test isCalendarDateDisabled', () => {
   it('returns true for dates outside min/max range', () => {
-    expect(isDateDisabled({
+    expect(isCalendarDateDisabled({
       targetDate: '2023-09-09',
       minDate: '2023-09-10'
     })).toBe(true);
 
-    expect(isDateDisabled({
+    expect(isCalendarDateDisabled({
       targetDate: '2023-09-21',
       maxDate: '2023-09-20'
     })).toBe(true);
   });
 
   it('returns true for weekend dates when disableWeekends is enabled', () => {
-    expect(isDateDisabled({
+    expect(isCalendarDateDisabled({
       targetDate: '2023-09-10',
       disableWeekends: true
     })).toBe(true);
   });
 
   it('returns true for explicitly disabled dates', () => {
-    expect(isDateDisabled({
+    expect(isCalendarDateDisabled({
       targetDate: '2023-09-11',
       disabledDates: ['2023-09-11']
     })).toBe(true);
   });
 
   it('supports month boundary checks', () => {
-    expect(isDateDisabled({
+    expect(isCalendarDateDisabled({
       targetDate: new Date(2023, 8, 1),
       minDate: '2023-09-01',
       maxDate: '2023-12-31',
       unit: 'month'
     })).toBe(false);
 
-    expect(isDateDisabled({
+    expect(isCalendarDateDisabled({
       targetDate: new Date(2023, 7, 1),
       minDate: '2023-09-01',
       unit: 'month'

--- a/src/utils/__tests__/set-date-picker-label.test.ts
+++ b/src/utils/__tests__/set-date-picker-label.test.ts
@@ -3,7 +3,7 @@ import { CalendarType, YearType } from '@/interfaces';
 import { setDatePickerLabel } from '../index';
 
 describe('Test setDatePickerLabel', () => {
-  it('should return string of time according to different arguments', () => {
+  it('formats date picker labels for different calendar types', () => {
     const baseTestCase = {
       selectedDate: new Date('2023/09/11'),
       formatYear: 2023,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -89,7 +89,7 @@ export const isDateOutsideRange = ({
 
 export const isDateOutOfRange = isDateOutsideRange;
 
-export const isDateDisabled = ({
+export const isCalendarDateDisabled = ({
   targetDate,
   minDate,
   maxDate,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -54,7 +54,7 @@ export const getValidDate = (dateValue: Date | string | undefined) => {
   return parsedDate.isValid() ? parsedDate.toDate() : undefined;
 };
 
-export const isDateOutOfRange = ({
+export const isDateOutsideRange = ({
   targetDate,
   minDate,
   maxDate,
@@ -82,6 +82,52 @@ export const isDateOutOfRange = ({
 
   if (normalizedMaxDate && normalizedTargetDate.isAfter(normalizedMaxDate)) {
     return true;
+  }
+
+  return false;
+};
+
+export const isDateOutOfRange = isDateOutsideRange;
+
+export const isDateDisabled = ({
+  targetDate,
+  minDate,
+  maxDate,
+  unit = 'day',
+  disableWeekends = false,
+  disabledDates = []
+}: {
+  targetDate: Date | string | undefined,
+  minDate?: Date | string,
+  maxDate?: Date | string,
+  unit?: DateBoundaryUnit,
+  disableWeekends?: boolean,
+  disabledDates?: (Date | string)[]
+}) => {
+  const parsedTargetDate = getValidDate(targetDate);
+  if (!parsedTargetDate) return false;
+
+  if (isDateOutsideRange({
+    targetDate: parsedTargetDate,
+    minDate,
+    maxDate,
+    unit
+  })) {
+    return true;
+  }
+
+  if (unit === 'day' && disableWeekends && [0, 6].includes(dayjs(parsedTargetDate).day())) {
+    return true;
+  }
+
+  if (unit === 'day' && disabledDates.length > 0) {
+    const targetDateTimestamp = dayjs(parsedTargetDate).startOf('day').valueOf();
+    const disabledDateTimestamps = disabledDates
+      .map((date) => getValidDate(date))
+      .filter((date): date is Date => date !== undefined)
+      .map((date) => dayjs(date).startOf('day').valueOf());
+
+    return disabledDateTimestamps.includes(targetDateTimestamp);
   }
 
   return false;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -87,8 +87,6 @@ export const isDateOutsideRange = ({
   return false;
 };
 
-export const isDateOutOfRange = isDateOutsideRange;
-
 export const isCalendarDateDisabled = ({
   targetDate,
   minDate,


### PR DESCRIPTION
Implement new properties to control date selection in the calendar:
- `minDate`: Set a minimum selectable date.
- `maxDate`: Set a maximum selectable date.
- `disableWeekends`: Prevent selection of Saturday and Sunday.
- `disabledDates`: Provide an explicit list of dates that cannot be selected.

These properties are passed down from `ROCDatePicker` to `DateCalendar` and validated through new tests. The README has been updated to reflect these additions.